### PR TITLE
Added adjustable Framerates

### DIFF
--- a/NaturewatchCameraServer.py
+++ b/NaturewatchCameraServer.py
@@ -1,8 +1,11 @@
 #!/usr/bin/env python
 import json
+import sys
+
+sys.path.append('/home/pi/.local/lib/python3.5/site-packages')
+
 import cv2
 import os
-import sys
 from http.server import BaseHTTPRequestHandler, HTTPServer
 from socketserver import ThreadingMixIn
 from ChangeDetector import ChangeDetector
@@ -177,7 +180,8 @@ class CamHandler(BaseHTTPRequestHandler):
                 "fix_camera_settings": config["fix_camera_settings"],
                 "iso": config["iso"],
                 "shutter_speed": config["shutter_speed"],
-                "rotate_camera": config["rotate_camera"]
+                "rotate_camera": config["rotate_camera"],
+                "framerate": config["framerate"]
             }
             json_data = json.dumps(send_data)
             self.wfile.write(json_data.encode("utf-8"))
@@ -253,6 +257,22 @@ class CamHandler(BaseHTTPRequestHandler):
             new_config = changeDetectorInstance.fix_exposure(int(data["exposure"]))
             self.update_config(new_config)
 
+            self.wfile.write(b'success')
+            
+        # POST request - Setting a new framerate
+        elif self.path.endswith('framerate'):
+            self.send_response(200)
+            self.send_header('Content-Type', 'text/html')
+            self.end_headers()
+            
+            data_string = self.rfile.read(int(self.headers['Content-Length']))
+            data = json.loads(data_string.decode('utf-8'))
+            
+            print("Framerate: {}".format(data["framerate"]))
+            
+            new_config = changeDetectorInstance.setFramerate(int(data["framerate"]))
+            self.update_config(new_config)
+            
             self.wfile.write(b'success')
 
     @staticmethod

--- a/config.json
+++ b/config.json
@@ -16,5 +16,6 @@
     "min_photo_interval_s": 1,
     "fix_camera_settings": 0,
     "iso": 800,
-    "shutter_speed": 8000
+    "shutter_speed": 8000,
+    "framerate": 24
 }

--- a/www/css/styles.css
+++ b/www/css/styles.css
@@ -1,2 +1,15 @@
-body{margin-top:15px;margin-bottom:15px}#feed img{width:100%}a.btn,button{width:100%;margin-top:15px;border-radius:0!important}.btn-group{width:100%}.btn-group label{width:100%;border-radius:0}#sensitivity-controls button,#flip-controls button{margin-top:0;border-top:1px solid white}#photos img{width:100%}#photos .col-md-4,#photos .col-md-12{margin-top:15px}.gap{margin-top:20px;margin-bottom:20px}input[type="range"]{width:100%}label{width:100%;height:38px;color:#fff;padding:8px 12px;border-top:1px solid white;margin-bottom:0}.bg-tertiary{background:#eee;padding:12px}.no-top-margin{margin-top:0;border-top:1px solid white}
+body{margin-top:15px;margin-bottom:15px}
+#feed img{width:100%}
+a.btn,button{width:100%;margin-top:15px;border-radius:0!important}
+.btn-group{width:100%}
+.btn-group label{width:100%;border-radius:0}
+#sensitivity-controls button,#flip-controls button{margin-top:0;border-top:1px solid white}
+#photos img{width:100%}
+#photos .col-md-4,#photos .col-md-12{margin-top:15px}
+.gap{margin-top:20px;margin-bottom:20px}
+input[type="range"]{width:100%}
+label{width:100%;height:38px;color:#fff;padding:8px 12px;border-top:1px solid white;margin-bottom:0}
+.bg-tertiary{background:#eee;padding:12px}
+.no-top-margin{margin-top:0;border-top:1px solid white}
+.top-margin{margin-top: 15px;}
 /* This beautiful CSS-File has been crafted with LESS (lesscss.org) and compiled by simpLESS (wearekiss.com/simpless) */

--- a/www/index.html
+++ b/www/index.html
@@ -31,6 +31,13 @@
                         <button type="button" id="flip-default" class="btn btn-secondary" data-dest="flip-default">Default</button>
                         <button type="button" id="flip-180" class="btn btn-secondary" data-dest="flip-180">Flip 180</button>
                     </div>
+
+                    <label for="framerate-range" class="bg-secondary top-margin">Framerate: <span></span></label>
+                    <div class="bg-tertiary">
+                        <input type="range" class="form-control-range" id="framerate-range" min="1" max="24" step="1">
+                    </div>
+                    <button type="button" class="btn btn-secondary" data-dest="update-framerate">Update Framerate Settings</button>
+                    
                     <button type="button" class="btn btn-secondary" data-dest="controls">Exposure Mode</button>
                     <div id="camera-controls">
                         <div class="btn-group" id="mode-controls">
@@ -42,7 +49,7 @@
                             <div class="bg-tertiary">
                                 <input type="range" class="form-control-range" id="shutter-range" min="0" max="21" step="1">
                             </div>
-                            <button type="button" class="btn btn-secondary no-top-margin" data-dest="update-manual">Update Manual Settings</button>
+                        <button type="button" class="btn btn-secondary" data-dest="update-manual">Update Manual Settings</button>
                         </div>
                     </div>
                 </div>

--- a/www/js/scripts.js
+++ b/www/js/scripts.js
@@ -173,9 +173,11 @@ $(document).ready(function() {
         }
         else if (dataDest == "update-manual") {
             sendManualSettings();
-            $("#mode-auto").removeClass("active");
-            $("#mode-manual").addClass("active");
         }
+        else if (dataDest == "update-framerate") {
+            sendFramerateSettings();
+        }
+        
         else sendGetRequest(dataDest);
     });
 
@@ -184,7 +186,10 @@ $(document).ready(function() {
         $(this).trigger('change');
         console.log($(this).val());
         if ($(this).attr('id') == "shutter-range") {
-            $("label[for='" + $(this).attr('id') + "'] span").html(Object.keys(cameraShutterSpeeds)[$(this).val()]);
+            $("label[for='shutter-range'] span").html(Object.keys(cameraShutterSpeeds)[$(this).val()]);
+        }
+        else if ($(this).attr('id') == "framerate-range"){
+            $("label[for='framerate-range'] span").html($(this).val());
         }
     });
 });
@@ -231,6 +236,8 @@ function getCameraStatus() {
             $("#mode-auto").removeClass("active");
             $("#manual-controls").show();
         }
+        
+        $("label[for='framerate-range'] span").html(String(data.framerate));
 
         // Exposure slider settings
         $.each(cameraShutterSpeeds, function (key, value) {
@@ -294,6 +301,8 @@ function sendTime(t) {
 }
 
 function sendManualSettings() {
+    
+    
     var iso = parseInt($("#iso-range").val());
     var shutter = Object.keys(cameraShutterSpeeds)[$("#shutter-range").val()];
     var shutter_us = cameraShutterSpeeds[shutter];
@@ -308,6 +317,25 @@ function sendManualSettings() {
         data: postData,
         success: function() {
             console.log("Sent exposure settings to Python server.");
+            return true;
+        },
+        timeout: 1000
+    });
+}
+    
+function sendFramerateSettings(){
+    var framerate = $("#framerate-range").val();
+    console.log("Framerate: " + framerate)
+    var postData = JSON.stringify({"framerate": framerate});
+    
+    $.ajax({
+        type: "POST",
+        url: baseURL + 'framerate',
+        dataType: 'json',
+        contentType: 'application/json',
+        data: postData,
+        success: function(){
+            console.log("Sent framerate settings to Python server.");
             return true;
         },
         timeout: 1000

--- a/www/js/scripts.js
+++ b/www/js/scripts.js
@@ -238,6 +238,7 @@ function getCameraStatus() {
         }
         
         $("label[for='framerate-range'] span").html(String(data.framerate));
+        $("#framerate-range").val(data.framerate);
 
         // Exposure slider settings
         $.each(cameraShutterSpeeds, function (key, value) {


### PR DESCRIPTION
Hi,

I noticed that by altering the default frame rate I've been able to get greater stability out of my setup, so I have added in the ability to change the frame rate from the web interface.

I've added a new function into ChangeDetector which sends a new framerate to the picamera, added in the required bits for the config.json, and I've made a couple alterations to the logging.

The NaturewatchCameraServer file has an extra elif to handle the new slider on the web interface, and log the change.

config.json has the extra framerates variable.

The css file, a new 'top-margin' class which adds a 15px margin at the top of the element, so that the new slider and label will fit with the rest of the style.

The html file has the new slider and label.

The scripts.js file handles the framerates slider in a similar way to the shutter speed slider. 

By putting the frame rates down to about 5 I get roughly a full day out the the camera before it crashes. When set to '1' the auto white balance seems to struggle and the images go green, and underexpose/overexpose.

Thanks
Steve