### PR TITLE
Added unique ID to hotspot name 

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,3 +67,4 @@ testing your PR against the `dev` branch, which has more experimental features.
 ## Support
 
 If you require support, please head over to the [My Naturewatch Forum](https://mynaturewatch.net/forum).
+

--- a/helpers/cfgsetup.py
+++ b/helpers/cfgsetup.py
@@ -49,4 +49,4 @@ if changedSettings == 1:
     with open(hostConfigFileName, "w") as file:
         file.writelines(hostConfigFile)
     print("Updated hostapd.conf.")
-    os.system("sudo reboot now")
+#    os.system("sudo reboot now")

--- a/helpers/cfgsetup.py
+++ b/helpers/cfgsetup.py
@@ -20,7 +20,7 @@ print("hostapd configuration - SSID: " + currentSSID)
 #configFilePassphrase = nwConfigFile[3].strip()
 #if "myNatureWatchCam" in configFileSSID :
 unique_id = subprocess.check_output("sed -n 's/^Serial\s*: 0*//p' /proc/cpuinfo", shell=True)
-configFileSSID = "myNatureWatchCam-" + unique_id.strip().decode('utf-8')
+configFileSSID = "MyNaturewatch-" + unique_id.strip().decode('utf-8')
 print("Wifi Updated to unique name")
 
 #print("Boot configuration - SSID: " + configFileSSID)

--- a/helpers/cfgsetup.py
+++ b/helpers/cfgsetup.py
@@ -8,23 +8,23 @@ hostConfigFileName = "/etc/hostapd/hostapd.conf"
 with open(hostConfigFileName, "r") as file:
     hostConfigFile = file.readlines()
 currentSSID = hostConfigFile[2][5:].strip()
-currentPassphrase = hostConfigFile[10][15:].strip()
+#currentPassphrase = hostConfigFile[10][15:].strip()
 print("hostapd configuration - SSID: " + currentSSID)
-print("hostapd configuration - Passphrase: " + currentPassphrase)
+#print("hostapd configuration - Passphrase: " + currentPassphrase)
 
 # get SSID and passphrase from user configuration file
-nwConfigFileName = "/boot/_naturewatch-configuration.txt"
-with open(nwConfigFileName, "r") as file:
-    nwConfigFile = file.readlines()
-configFileSSID = nwConfigFile[1].strip()
-configFilePassphrase = nwConfigFile[3].strip()
-if "myNatureWatchCam" in configFileSSID :
-      unique_id = subprocess.check_output("sed -n 's/^Serial\s*: 0*//p' /proc/cpuinfo", shell=True)
-      configFileSSID = "myNatureWatchCam-" + unique_id.strip().decode('utf-8')
-      print("Wifi Updated to unique name")
+#nwConfigFileName = "/boot/_naturewatch-configuration.txt"
+#with open(nwConfigFileName, "r") as file:
+#    nwConfigFile = file.readlines()
+#configFileSSID = nwConfigFile[1].strip()
+#configFilePassphrase = nwConfigFile[3].strip()
+#if "myNatureWatchCam" in configFileSSID :
+unique_id = subprocess.check_output("sed -n 's/^Serial\s*: 0*//p' /proc/cpuinfo", shell=True)
+configFileSSID = "myNatureWatchCam-" + unique_id.strip().decode('utf-8')
+print("Wifi Updated to unique name")
 
-print("Boot configuration - SSID: " + configFileSSID)
-print("Boot configuration - Passphrase: " + configFilePassphrase)
+#print("Boot configuration - SSID: " + configFileSSID)
+#print("Boot configuration - Passphrase: " + configFilePassphrase)
 
 if configFileSSID == currentSSID:
     print("Config file and hostapd SSIDs match. No need to change them.")
@@ -33,17 +33,17 @@ else:
     print("Updating hostapd config with new SSID...")
     changedSettings = 1
 
-if configFilePassphrase == currentPassphrase:
-    print("Config file and hostapd passphrases match. No need to change them.")
-else:
-    hostConfigFile[10] = "wpa_passphrase=" + configFilePassphrase + "\n"
-    print("Updating hostapd config with new passphrase...")
-    changedSettings = 1
+#if configFilePassphrase == currentPassphrase:
+#    print("Config file and hostapd passphrases match. No need to change them.")
+#else:
+#    hostConfigFile[10] = "wpa_passphrase=" + configFilePassphrase + "\n"
+#    print("Updating hostapd config with new passphrase...")
+#    changedSettings = 1
 
-if os.path.isfile("/home/pi/firstboot"):
-    os.system("rm /home/pi/firstboot")
-    os.system("sudo raspi-config --expand-rootfs")
-    changedSettings = 1
+#if os.path.isfile("/home/pi/firstboot"):
+#    os.system("rm /home/pi/firstboot")
+#    os.system("sudo raspi-config --expand-rootfs")
+#    changedSettings = 1
 
 if changedSettings == 1:
     with open(hostConfigFileName, "w") as file:

--- a/os/modules/naturewatchcamera/start_chroot_script
+++ b/os/modules/naturewatchcamera/start_chroot_script
@@ -53,15 +53,19 @@ pushd /home/pi
 		echo "Installing repo dependencies"
 		pip3 install -r requirements-pi.txt
 
-		echo "Adding service"
+		echo "Adding services"
 		mv helpers/python.naturewatch.service /etc/systemd/system/python.naturewatch.service
+		mv helpers/wifisetup.service /etc/systemd/system/wifisetup.service
+		
 
 	popd
 popd
 
-echo "Enabling service"
+echo "Enabling services"
 chmod 644 /etc/systemd/system/python.naturewatch.service
 systemctl enable python.naturewatch.service
+chmod 644 /etc/systemd/system/wifisetup.service
+systemctl enable wifisetup.service
 
 unpack /filesystem/home/pi /home/"${BASE_USER}" "${BASE_USER}"
 # Unpack root at the end, so files are modified before


### PR DESCRIPTION
PR fixes https://github.com/interactionresearchstudio/NaturewatchCameraServer/issues/45 . Currently on first boot the name of the camera is myNatureWatchCam, but is replaced with myNatureWatchCam-XXXXXX (Unique ID) on future boots