### PR TITLE
Download video from mobile and desktop devices

### DIFF
--- a/naturewatch_camera_server/static/client/src/gallery/GalleryGrid.js
+++ b/naturewatch_camera_server/static/client/src/gallery/GalleryGrid.js
@@ -91,6 +91,13 @@ class GalleryGrid extends React.Component {
                             </BrowserView>
                         </div>
                     }
+                    {this.state.activeContent.endsWith(".mp4") &&
+                        <div className="footer-content">
+                            <p className="mr-auto">
+                               <a href={this.state.activeContent} download={this.state.activeContent.substring(this.state.activeContent.lastIndexOf('/')+1)}>Download Video</a>
+                            </p>
+                        </div>
+                    }
                     <Button variant="primary" className="btn-icon" onClick={this.handleModalExit}>
                         <Cancel/>
                     </Button>


### PR DESCRIPTION
There is a link on the modal that allows you to download the video. Fixes #51. 

Tested on:
iOS 14 (Safari) ✅
iPadOS 14 (Safari) ✅
Android 11 (Chrome) ✅