### PR TITLE
added reboot to remove hotspot name inconsistencies 

### DIFF
--- a/helpers/cfgsetup.py
+++ b/helpers/cfgsetup.py
@@ -49,4 +49,4 @@ if changedSettings == 1:
     with open(hostConfigFileName, "w") as file:
         file.writelines(hostConfigFile)
     print("Updated hostapd.conf.")
-#    os.system("sudo reboot now")
+    os.system("sudo reboot now")

--- a/os/modules/naturewatchcamera/end_chroot_script
+++ b/os/modules/naturewatchcamera/end_chroot_script
@@ -7,5 +7,3 @@
 
 set -x
 set -e
-
-reboot now

--- a/os/modules/naturewatchcamera/end_chroot_script
+++ b/os/modules/naturewatchcamera/end_chroot_script
@@ -8,3 +8,4 @@
 set -x
 set -e
 
+reboot now


### PR DESCRIPTION
Added a reboot to the script that appends the hotspot name with a unique ID. This now stops showing the hotspot name without the unique ID on first boot.

Tested on Raspberry Pi Zero W