### PR TITLE
ZIP file streamer to download all photos

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -249,3 +249,4 @@ dist
 package-lock.json
 yarn-lock.json
 yarn.lock
+*.zip

--- a/naturewatch_camera_server/FileSaver.py
+++ b/naturewatch_camera_server/FileSaver.py
@@ -7,8 +7,6 @@ import datetime
 from subprocess import call
 import zipfile
 
-from naturewatch_camera_server.ZipfileGenerator import ZipfileGenerator
-
 try:
     import picamera
     import picamera.array
@@ -136,12 +134,6 @@ class FileSaver(Thread):
         filename = "video_"+timestamp.strftime('%Y-%m-%d-%H-%M-%S')
         filename = filename.strip()
         return filename
-
-    def download_all_photos(self, paths):
-        self.logger.info('download_all_photos(' + str(paths) + ')')
-        # map the names to fullpaths
-        fullpaths = map(lambda p : os.path.join(self.config["photos_path"], p), paths)
-        return ZipfileGenerator(fullpaths).get()
 
     def download_zip(self, filename):
         input_file = os.path.join(self.config["videos_path"], filename)

--- a/naturewatch_camera_server/FileSaver.py
+++ b/naturewatch_camera_server/FileSaver.py
@@ -7,6 +7,7 @@ import datetime
 from subprocess import call
 import zipfile
 
+from naturewatch_camera_server.ZipfileGenerator import ZipfileGenerator
 
 try:
     import picamera
@@ -135,6 +136,12 @@ class FileSaver(Thread):
         filename = "video_"+timestamp.strftime('%Y-%m-%d-%H-%M-%S')
         filename = filename.strip()
         return filename
+
+    def download_all_photos(self, paths):
+        self.logger.info('download_all_photos(' + str(paths) + ')')
+        # map the names to fullpaths
+        fullpaths = map(lambda p : os.path.join(self.config["photos_path"], p), paths)
+        return ZipfileGenerator(fullpaths).get()
 
     def download_zip(self, filename):
         input_file = os.path.join(self.config["videos_path"], filename)

--- a/naturewatch_camera_server/ZipfileGenerator.py
+++ b/naturewatch_camera_server/ZipfileGenerator.py
@@ -1,0 +1,52 @@
+from io import RawIOBase
+from zipfile import ZipFile, ZipInfo, ZIP_DEFLATED
+
+import os
+
+class ZipfileGenerator():
+
+    class UnseekableStream(RawIOBase):
+        def __init__(self):
+            self._buffer = b''
+
+        def writable(self):
+            return True
+
+        def write(self, b):
+            if self.closed:
+                raise ValueError('Stream was closed!')
+            self._buffer += b
+            return len(b)
+
+        def get(self):
+            chunk = self._buffer
+            self._buffer = b''
+            return chunk
+
+    # Constructor
+    def __init__(self, paths):
+        self.paths   = paths
+
+    # Generator
+    def get(self):
+
+        output = ZipfileGenerator.UnseekableStream()
+
+        with ZipFile(output, mode='w') as zf:
+
+            for path in self.paths:
+
+                z_info = ZipInfo.from_file(path,os.path.join('photos',os.path.basename(path)))
+                # it's not worth the resources, achieves max 0.1% on JPEGs...
+                #z_info.compress_type = ZIP_DEFLATED
+
+                with open(path, 'rb') as entry, zf.open(z_info, mode='w') as dest:
+
+                    for chunk in iter(lambda: entry.read(16384), b''):
+                        dest.write(chunk)
+                        # Yield chunk of the zip file stream in bytes.
+                        yield output.get()
+
+        # ZipFile was closed.
+        yield output.get()
+

--- a/naturewatch_camera_server/data.py
+++ b/naturewatch_camera_server/data.py
@@ -4,6 +4,8 @@ import time
 import json
 import os
 
+from .ZipfileGenerator import ZipfileGenerator
+
 data = Blueprint('data', __name__)
 
 
@@ -46,9 +48,11 @@ def download_all():
 @data.route('/download/photos.zip')
 def download_all_photos():
     # just for now... we should take an array of file names
-    photos_list = construct_directory_list(current_app, current_app.user_config["photos_path"])
-    return Response(current_app.file_saver.download_all_photos(photos_list),
-                    mimetype='application/zip')
+    photos_path = current_app.user_config["photos_path"]
+    photos_list = construct_directory_list(current_app, photos_path)
+
+    paths = list(map(lambda fn : {'filename': os.path.join(photos_path, fn), 'arcname': fn }, photos_list))
+    return Response(ZipfileGenerator(paths).get(), mimetype='application/zip')
 
 
 @data.route('/photos/<filename>', methods=["DELETE"])

--- a/naturewatch_camera_server/data.py
+++ b/naturewatch_camera_server/data.py
@@ -43,6 +43,13 @@ def download_all():
     current_app.file_saver.download_all_video()
     return Response("{'NOT_FOUND':'" "'}", status=404, mimetype='application/json')
 
+@data.route('/download/photos.zip')
+def download_all_photos():
+    # just for now... we should take an array of file names
+    photos_list = construct_directory_list(current_app, current_app.user_config["photos_path"])
+    return Response(current_app.file_saver.download_all_photos(photos_list),
+                    mimetype='application/zip')
+
 
 @data.route('/photos/<filename>', methods=["DELETE"])
 def delete_photo(filename):

--- a/naturewatch_camera_server/data.py
+++ b/naturewatch_camera_server/data.py
@@ -30,31 +30,6 @@ def get_photo(filename):
         return Response("{'NOT_FOUND':'" + filename + "'}", status=404, mimetype='application/json')
 
 
-@data.route('/download/<filename>')
-def get_download(filename):
-    file_path = current_app.user_config["videos_path"] + filename + '.mp4'
-    if os.path.isfile(os.path.join(file_path)):
-        output = current_app.file_saver.download_zip(filename + '.mp4')
-        return send_from_directory(os.path.join('static/data/videos'), filename + ".mp4" + ".zip", mimetype="application/zip")
-    else:
-        return Response("{'NOT_FOUND':'" + filename + "'}", status=404, mimetype='application/json')
-
-
-@data.route('/download/video')
-def download_all():
-    current_app.file_saver.download_all_video()
-    return Response("{'NOT_FOUND':'" "'}", status=404, mimetype='application/json')
-
-@data.route('/download/photos.zip')
-def download_all_photos():
-    # just for now... we should take an array of file names
-    photos_path = current_app.user_config["photos_path"]
-    photos_list = construct_directory_list(current_app, photos_path)
-
-    paths = list(map(lambda fn : {'filename': os.path.join(photos_path, fn), 'arcname': fn }, photos_list))
-    return Response(ZipfileGenerator(paths).get(), mimetype='application/zip')
-
-
 @data.route('/photos/<filename>', methods=["DELETE"])
 def delete_photo(filename):
     file_path = current_app.user_config["photos_path"] + filename
@@ -92,6 +67,25 @@ def delete_video(filename):
             return Response('{"SUCCESS": "' + filename + '"}', status=200, mimetype='application/json')
         else:
             return Response('{"ERROR": "' + filename + '"}', status=500, mimetype='application/json')
+
+
+def get_all_files(current_app, src_path):
+    # just for now... we should take an array of file names
+    src_list = construct_directory_list(current_app, src_path)
+    paths = list(map(lambda fn : {'filename': os.path.join(src_path, fn), 'arcname': fn }, src_list))
+    return Response(ZipfileGenerator(paths).get(), mimetype='application/zip')
+
+
+@data.route('/download/videos.zip')
+def download_all_videos():
+    videos_path = current_app.user_config["videos_path"]
+    return get_all_files(current_app,videos_path)
+
+
+@data.route('/download/photos.zip')
+def download_all_photos():
+    photos_path = current_app.user_config["photos_path"]
+    return get_all_files(current_app,videos_path)
 
 
 def construct_directory_list(current_app, path):


### PR DESCRIPTION
This MR adds a new route (`/data/download/photos.zip`) to download all photos.

ATM, the route does not take any arguments and just ZIPs all the files in the `/data/photos`. It is however intended to have the client side pass an array of file names (already implemented this way in `FileSaver.download_all_photos(paths)`).

Please note that the ZIP file itself is not compressed at all, as it is useless with JPEG files (no gain at all with DEFLATED). Moreover, this uses only streams, which means that the ZIP file never touches the disk, and everything is done with only little buffers (16KB for now).

There is however **one drawback**: the technique used is **available only from Python 3.5** on (see https://docs.python.org/3/library/zipfile.html and "_unseekable streams_").

Implements #50 