### PR TITLE
Use calculated video length

### DIFF
--- a/naturewatch_camera_server/FileSaver.py
+++ b/naturewatch_camera_server/FileSaver.py
@@ -118,7 +118,7 @@ class FileSaver(Thread):
             filenameMp4 = filenameMp4 + ".mp4"
             self.logger.info('FileSaver: done writing video ' + filename)
             input_video = os.path.join(self.config["videos_path"], filename)
-            stream.copy_to(input_video, seconds=15)
+            stream.copy_to(input_video, seconds = self.config["video_duration_before_motion"] + self.config["video_duration_after_motion"])
             output_video = os.path.join(self.config["videos_path"], filenameMp4)
             call(["MP4Box", "-fps", str(self.config["frame_rate"]), "-add", input_video, output_video])
             os.remove(input_video)


### PR DESCRIPTION
# Description

After altering `video_duration_before_motion` and `video_duration_after_motion`, I noticed that the videos were still the same length. This is because the video length is hard-coded when saving the video. This PR fixes that by replacing the hard-coded `15` with the calculated duration.

This is actually a partial revert of 2d825790283f2be6b9ba17bf413f75998c6326e2 - so there might be a reason for the hardcoded value that I'm missing.

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

I have ssh-ed onto the Pi and fixed the code manually. 

**Tested on the following devices**:
- [ ] Development environment (Linux, Windows, or MacOS)
- [x] Pi Zero W
- [ ] Pi 3A+
- [ ] Pi 3B+
- [ ] Pi 4

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] New and existing unit tests pass locally with my changes