### PR TITLE
Remove redundant calls to enable camera, add legacy call

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -35,7 +35,7 @@ If applicable, add screenshots to help explain your problem.
  - Version [e.g. 22]
 
 **Hardware**
-- Device: [e.g. Pi Zero W]
+- Device: [e.g. Pi Zero 2 W]
 - Camera: [e.g. ZeroCam v1.0]
 - Naturewatch Camera software version: [e.g. v1.4.1]
 - Power supply used: [e.g. Official Pi Adapter]

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -18,6 +18,7 @@ Please also list any relevant details for your test configuration.
 
 **Tested on the following devices**:
 - [ ] Development environment (Linux, Windows, or MacOS)
+- [ ] Pi Zero 2 W
 - [ ] Pi Zero W
 - [ ] Pi 3A+
 - [ ] Pi 3B+

--- a/os/modules/naturewatchcamera/start_chroot_script
+++ b/os/modules/naturewatchcamera/start_chroot_script
@@ -40,8 +40,7 @@ echo "$NATUREWATCHCAMERA_VAR"
  apt-get install -y gpac
 
 echo "Enabling legacy camera support for Pi Zero W 2"
-raspi-config nonint do_camera 1
-echo "start_x=1" >> /boot/config.txt
+raspi-config nonint do_legacy 0
 
 echo "Installing OpenCV"
 pip3 install -U pip numpy opencv-python-headless


### PR DESCRIPTION
# Description
Removed redundant calls to enable camera, added the correct way to add legacy support, as per @Vincent-Stragier 's comment.

Fixes # (issue)
N/A

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Tested on Pi Zero W and Pi Zero 2 W with photos and videos.

**Tested on the following devices**:
- [ ] Development environment (Linux, Windows, or MacOS)
- [x] Pi Zero W
- [x] Pi Zero 2 W
- [ ] Pi 3A+
- [ ] Pi 3B+
- [ ] Pi 4

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes